### PR TITLE
1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.8 (2024-03-07)
+
+* add more detail to "invalid sync check" error logging
+* don't exit sync check task on service temporarily unavailable or invalid login
+* don't use empty site id for logins
+
 ## 1.2.7 (2024-02-23)
 
 * catch site is None on logout to prevent "have you logged in" errors

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -1,6 +1,6 @@
 """Constants for pyadtpulse."""
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 DEFAULT_API_HOST = "https://portal.adtpulse.com"
 API_HOST_CA = "https://portal-ca.adtpulse.com"  # Canada

--- a/pyadtpulse/pulse_connection.py
+++ b/pyadtpulse/pulse_connection.py
@@ -215,9 +215,10 @@ class PulseConnection(PulseQueryManager):
         data = {
             "usernameForm": self._authentication_properties.username,
             "passwordForm": self._authentication_properties.password,
-            "networkid": self._authentication_properties.site_id,
             "fingerprint": self._authentication_properties.fingerprint,
         }
+        if self._authentication_properties.site_id:
+            data["networkid"] = self._authentication_properties.site_id
         await self._login_backoff.wait_for_backoff()
         try:
             response = await self.async_query(

--- a/pyadtpulse/pulse_query_manager.py
+++ b/pyadtpulse/pulse_query_manager.py
@@ -109,7 +109,8 @@ class PulseQueryManager:
         Raises:
             PulseServerConnectionError: If the server returns an error code.
             PulseServiceTemporarilyUnavailableError: If the server returns a
-                Retry-After header."""
+                HTTP status code of 429 or 503.
+        """
 
         def get_retry_after(retry_after: str) -> int | None:
             """
@@ -212,7 +213,7 @@ class PulseQueryManager:
         Raises:
             PulseClientConnectionError: If the client cannot connect
             PulseServerConnectionError: If there is a server error
-            PulseServiceTemporarilyUnavailableError: If the server returns a Retry-After header
+            PulseServiceTemporarilyUnavailableError: If the server returns an HTTP status code of 429 or 503
             PulseNotLoggedInError: if not logged in and task is waiting for longer than
                 ADT_DEFAULT_LOGIN_TIMEOUT seconds
         """

--- a/pyadtpulse/pyadtpulse_async.py
+++ b/pyadtpulse/pyadtpulse_async.py
@@ -443,10 +443,18 @@ class PyADTPulseAsync:
                 return False
             pattern = r"\d+[-]\d+[-]\d+"
             if not re.match(pattern, response_text):
-                LOG.warning(
-                    "Unexpected sync check format",
-                )
-                self._pulse_connection.check_login_errors((code, response_text, url))
+                warning_msg = "Unexpected sync check format"
+                try:
+                    self._pulse_connection.check_login_errors(
+                        (code, response_text, url)
+                    )
+                except Exception as ex:
+                    warning_msg += f": {ex}"
+                    raise
+                else:
+                    warning_msg += ": skipping"
+                finally:
+                    LOG.warning(warning_msg)
                 return False
             split_text = response_text.split("-")
             if int(split_text[0]) > 9 or int(split_text[1]) > 9:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyadtpulse"
-version = "1.2.7"
+version = "1.2.8"
 description = "Python interface for ADT Pulse security systems"
 authors = ["Ryan Snodgrass"]
 maintainers = ["Robert Lippmann"]


### PR DESCRIPTION
## 1.2.8 (2024-03-07)

* add more detail to "invalid sync check" error logging
* don't exit sync check task on service temporarily unavailable or invalid login
* don't use empty site id for logins