### PR TITLE
1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.2.9 (2024-03-11)
+
+* ignore query string in check_login_errors().  This should fix a bug where the task was logged out
+  but not correctly being identified
+* remove unnecessary warning in alarm status check
+* add arm night
+* refactor update_alarm_from_etree()
+* bump to newer user agent
+* skip sync check if it will back off
+* fix linter issue in _initialize_sites
+
 ## 1.2.8 (2024-03-07)
 
 * add more detail to "invalid sync check" error logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.9 (2024-03-11)
+## 1.2.9 (2024-04-21)
 
 * ignore query string in check_login_errors().  This should fix a bug where the task was logged out
   but not correctly being identified

--- a/pyadtpulse/alarm_panel.py
+++ b/pyadtpulse/alarm_panel.py
@@ -21,6 +21,7 @@ ADT_ALARM_OFF = "off"
 ADT_ALARM_UNKNOWN = "unknown"
 ADT_ALARM_ARMING = "arming"
 ADT_ALARM_DISARMING = "disarming"
+ADT_ALARM_NIGHT = "night"
 
 ALARM_STATUSES = (
     ADT_ALARM_AWAY,
@@ -29,6 +30,7 @@ ALARM_STATUSES = (
     ADT_ALARM_UNKNOWN,
     ADT_ALARM_ARMING,
     ADT_ALARM_DISARMING,
+    ADT_ALARM_NIGHT,
 )
 
 ADT_ARM_DISARM_TIMEOUT: float = 20
@@ -128,6 +130,16 @@ class ADTPulseAlarmPanel:
         """
         with self._state_lock:
             return self._status == ADT_ALARM_DISARMING
+
+    @property
+    def is_armed_night(self) -> bool:
+        """Return if system is in night mode.
+
+        Returns:
+            bool: True if system is in night mode
+        """
+        with self._state_lock:
+            return self._status == ADT_ALARM_NIGHT
 
     @property
     def last_update(self) -> float:
@@ -241,6 +253,18 @@ class ADTPulseAlarmPanel:
         return self._sync_set_alarm_mode(connection, ADT_ALARM_AWAY, force_arm)
 
     @typechecked
+    def arm_night(self, connection: PulseConnection, force_arm: bool = False) -> bool:
+        """Arm the alarm in Night mode.
+
+        Args:
+            force_arm (bool, Optional): force system to arm
+
+        Returns:
+            bool: True if arm succeeded
+        """
+        return self._sync_set_alarm_mode(connection, ADT_ALARM_NIGHT, force_arm)
+
+    @typechecked
     def arm_home(self, connection: PulseConnection, force_arm: bool = False) -> bool:
         """Arm the alarm in Home mode.
 
@@ -287,6 +311,19 @@ class ADTPulseAlarmPanel:
             bool: True if arm succeeded
         """
         return await self._arm(connection, ADT_ALARM_HOME, force_arm)
+
+    @typechecked
+    async def async_arm_night(
+        self, connection: PulseConnection, force_arm: bool = False
+    ) -> bool:
+        """Arm alarm night async.
+
+        Args:
+            force_arm (bool, Optional): force system to arm
+        Returns:
+            bool: True if arm succeeded
+        """
+        return await self._arm(connection, ADT_ALARM_NIGHT, force_arm)
 
     @typechecked
     async def async_disarm(self, connection: PulseConnection) -> bool:

--- a/pyadtpulse/alarm_panel.py
+++ b/pyadtpulse/alarm_panel.py
@@ -198,7 +198,7 @@ class ADTPulseAlarmPanel:
             if arm_result is not None:
                 error_block = arm_result.find(".//div")
                 if error_block is not None:
-                    error_text = arm_result.text_contents().replace(
+                    error_text = arm_result.text_content().replace(
                         "Arm AnywayCancel\n\n", ""
                     )
                     LOG.warning(

--- a/pyadtpulse/alarm_panel.py
+++ b/pyadtpulse/alarm_panel.py
@@ -339,7 +339,8 @@ class ADTPulseAlarmPanel:
                         self._status = ADT_ALARM_HOME
                         self._last_arm_disarm = last_updated
                 else:
-                    LOG.warning("Failed to get alarm status from '%s'", text)
+                    if not text.startswith("Status Unavailable"):
+                        LOG.warning("Failed to get alarm status from '%s'", text)
                     self._status = ADT_ALARM_UNKNOWN
                     self._last_arm_disarm = last_updated
                     return

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -1,6 +1,6 @@
 """Constants for pyadtpulse."""
 
-__version__ = "1.2.8"
+__version__ = "1.2.9b0"
 
 DEFAULT_API_HOST = "https://portal.adtpulse.com"
 API_HOST_CA = "https://portal-ca.adtpulse.com"  # Canada

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -34,9 +34,9 @@ ADT_GATEWAY_MAX_OFFLINE_POLL_INTERVAL = 600.0
 ADT_MAX_BACKOFF: float = 5.0 * 60.0
 ADT_DEFAULT_HTTP_USER_AGENT = {
     "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/100.0.4896.127 Safari/537.36 Edg/100.0.1185.44"
+        "Chrome/122.0.0.0 Safari/537.36"
     )
 }
 

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -1,6 +1,6 @@
 """Constants for pyadtpulse."""
 
-__version__ = "1.2.9b0"
+__version__ = "1.2.9b1"
 
 DEFAULT_API_HOST = "https://portal.adtpulse.com"
 API_HOST_CA = "https://portal-ca.adtpulse.com"  # Canada

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -31,7 +31,7 @@ ADT_GATEWAY_STRING = "gateway"
 # than that
 ADT_DEFAULT_POLL_INTERVAL = 2.0
 ADT_GATEWAY_MAX_OFFLINE_POLL_INTERVAL = 600.0
-ADT_MAX_BACKOFF: float = 15.0 * 60.0
+ADT_MAX_BACKOFF: float = 5.0 * 60.0
 ADT_DEFAULT_HTTP_USER_AGENT = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "

--- a/pyadtpulse/const.py
+++ b/pyadtpulse/const.py
@@ -1,6 +1,6 @@
 """Constants for pyadtpulse."""
 
-__version__ = "1.2.9b1"
+__version__ = "1.2.9"
 
 DEFAULT_API_HOST = "https://portal.adtpulse.com"
 API_HOST_CA = "https://portal-ca.adtpulse.com"  # Canada

--- a/pyadtpulse/pulse_connection.py
+++ b/pyadtpulse/pulse_connection.py
@@ -120,7 +120,7 @@ class PulseConnection(PulseQueryManager):
             """
             self._login_in_progress = False
             url = self._connection_properties.make_url(ADT_LOGIN_URI)
-            if url == response_url_string:
+            if response_url_string.startswith(url):
                 error = tree.find(".//div[@id='warnMsgContents']")
                 if error is not None:
                     error_text = error.text_content()

--- a/pyadtpulse/pyadtpulse_async.py
+++ b/pyadtpulse/pyadtpulse_async.py
@@ -171,13 +171,15 @@ class PyADTPulseAsync:
         """
         # typically, ADT Pulse accounts have only a single site (premise/location)
         single_premise = tree.find(".//span[@id='p_singlePremise']")
-        if single_premise is not None:
+        if single_premise is not None and single_premise.text:
             site_name = single_premise.text
             start_time = 0.0
             if self._pulse_connection.detailed_debug_logging:
                 start_time = time.time()
-            # FIXME: this code works, but it doesn't pass the linter
-            signout_link = str(tree.find(".//a[@class='p_signoutlink']").get("href"))
+            temp = tree.find(".//a[@class='p_signoutlink']")
+            signout_link = None
+            if temp is not None:
+                signout_link = str(temp.get("href"))
             if signout_link:
                 m = re.search("networkid=(.+)&", signout_link)
                 if m and m.group(1) and m.group(1):

--- a/pyadtpulse/pyadtpulse_async.py
+++ b/pyadtpulse/pyadtpulse_async.py
@@ -272,9 +272,13 @@ class PyADTPulseAsync:
             relogin_interval = self._pulse_properties.relogin_interval * 60
             try:
                 await asyncio.sleep(self._pulse_properties.keepalive_interval * 60)
-                if self._pulse_connection_status.retry_after > time.time():
+                if (
+                    self._pulse_connection_status.retry_after > time.time()
+                    or self._pulse_connection_status.get_backoff().backoff_count
+                    > WARN_TRANSIENT_FAILURE_THRESHOLD
+                ):
                     LOG.debug(
-                        "%s: Skipping actions because retry_after > now", task_name
+                        "%s: Skipping actions because query will backoff", task_name
                     )
                     continue
                 if not self._pulse_connection.is_connected:

--- a/pyadtpulse/site.py
+++ b/pyadtpulse/site.py
@@ -78,6 +78,13 @@ class ADTPulseSite(ADTPulseSiteProperties):
             self._pulse_connection, force_arm=force_arm
         )
 
+    @typechecked
+    async def async_arm_night(self, force_arm: bool = False) -> bool:
+        """Arm system away async."""
+        return await self.alarm_control_panel.async_arm_night(
+            self._pulse_connection, force_arm=force_arm
+        )
+
     async def async_disarm(self) -> bool:
         """Disarm system async."""
         return await self.alarm_control_panel.async_disarm(self._pulse_connection)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyadtpulse"
-version = "1.2.9b1"
+version = "1.2.9"
 description = "Python interface for ADT Pulse security systems"
 authors = ["Ryan Snodgrass"]
 maintainers = ["Robert Lippmann"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyadtpulse"
-version = "1.2.8"
+version = "1.2.9b0"
 description = "Python interface for ADT Pulse security systems"
 authors = ["Ryan Snodgrass"]
 maintainers = ["Robert Lippmann"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyadtpulse"
-version = "1.2.9b0"
+version = "1.2.9b1"
 description = "Python interface for ADT Pulse security systems"
 authors = ["Ryan Snodgrass"]
 maintainers = ["Robert Lippmann"]


### PR DESCRIPTION
## 1.2.9 

* ignore query string in check_login_errors(). This should fix a bug where the task was logged out but not correctly being identified
* remove unnecessary warning in alarm status check
* add arm night
* refactor update_alarm_from_etree()
* bump to newer user agent
* skip sync check if it will back off
* fix linter issue in _initialize_sites
